### PR TITLE
Fix anchor navigation on quests page

### DIFF
--- a/quests/index.html
+++ b/quests/index.html
@@ -96,6 +96,28 @@ document.addEventListener('DOMContentLoaded', function() {
     setTimeout(() => { isScrolling = false; }, 700);
   }
 
+  // Переход по якорям на странице
+  document.querySelectorAll('a[href^="#"]').forEach(link => {
+    link.addEventListener('click', function(e) {
+      const targetId = this.getAttribute('href').slice(1);
+      const targetIndex = sections.findIndex(sec => sec.id === targetId);
+      if (targetIndex !== -1) {
+        e.preventDefault();
+        scrollToSection(targetIndex);
+      }
+    });
+  });
+
+  // Прокрутка к секции при открытии с хэшем
+  const initialHash = window.location.hash.slice(1);
+  if (initialHash) {
+    const targetIndex = sections.findIndex(sec => sec.id === initialHash);
+    if (targetIndex !== -1) {
+      // небольшая задержка, чтобы страница успела построиться
+      setTimeout(() => scrollToSection(targetIndex), 0);
+    }
+  }
+
   // Прокрутка колёсиком
   container.addEventListener('wheel', function(e) {
     if (isScrolling) { e.preventDefault(); return; }


### PR DESCRIPTION
## Summary
- Add hash-based navigation support to quests page to enable scrolling to sections via anchors
- Handle anchor link clicks and initial hash to scroll container to the correct section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a713f7f8e48326972c5eceedbb1f4c